### PR TITLE
Use available cores instead of total cores

### DIFF
--- a/common.py
+++ b/common.py
@@ -38,6 +38,13 @@ __all__ = [
 locale.setlocale(locale.LC_ALL, "C")
 
 
+def get_num_avail_cores() -> int:
+    if hasattr(os, "sched_getaffinity"):
+        return len(os.sched_getaffinity(0))
+    else:
+        return os.cpu_count()
+
+
 def glob(root, pattern):
     path = pathlib.Path(root)
     for match in path.glob(pattern):

--- a/ggws.py
+++ b/ggws.py
@@ -217,7 +217,7 @@ def torch_dir(options):
                 cur_token2id_txt,
                 torch_dir_,
                 "--num-workers",
-                str(get_num_avail_cores()),
+                str(get_num_avail_cores() - 1),
             ]
             both_args.append(args)
             if is_test:

--- a/ggws.py
+++ b/ggws.py
@@ -30,7 +30,7 @@ from shutil import copy as copy_paths
 
 import pydrobert.torch.command_line as torch_cmd
 
-from common import mkdir  # type: ignore (pylance might complain if in subdirectory)
+from common import mkdir, get_num_avail_cores  # type: ignore (pylance might complain if in subdirectory)
 
 
 locale.setlocale(locale.LC_ALL, "C")
@@ -212,7 +212,13 @@ def torch_dir(options):
 
             copy_paths(trn_src, trn_dest)
 
-            args = [trn_src, cur_token2id_txt, torch_dir_]
+            args = [
+                trn_src,
+                cur_token2id_txt,
+                torch_dir_,
+                "--num-workers",
+                str(get_num_avail_cores()),
+            ]
             both_args.append(args)
             if is_test:
                 with open(trn_src) as file_:

--- a/timit.py
+++ b/timit.py
@@ -670,7 +670,7 @@ def torch_dir(options):
         "--channel",
         "-1",
         "--num-workers",
-        str(get_num_avail_cores()),
+        str(get_num_avail_cores() - 1),
         "--force-as",
         force_as,
         "--preprocess",

--- a/timit.py
+++ b/timit.py
@@ -45,6 +45,8 @@ import ngram_lm  # type: ignore (pylance might complain if in subdirectory)
 from pydrobert.speech.compute import FrameComputer
 from pydrobert.speech.util import alias_factory_subclass_from_arg
 
+from common import get_num_avail_cores  # type: ignore
+
 
 locale.setlocale(locale.LC_ALL, "C")
 
@@ -136,7 +138,7 @@ def timit_data_prep(timit, data_root):
                     force_as = "wav"
             else:
                 try:
-                    sig = speech_util.read_signal(path, force_as="wav")
+                    sig = speech_util.read_signal(path, force_as=force_as)
                 except OSError as e:
                     raise OSError("Found both sphere and wav files!") from e
             dur = len(sig) / 16000
@@ -668,7 +670,7 @@ def torch_dir(options):
         "--channel",
         "-1",
         "--num-workers",
-        str(torch.multiprocessing.cpu_count()),
+        str(get_num_avail_cores()),
         "--force-as",
         force_as,
         "--preprocess",

--- a/wsj.py
+++ b/wsj.py
@@ -1797,7 +1797,7 @@ def torch_dir(options):
         "--channel",
         "-1",
         "--num-workers",
-        str(get_num_avail_cores()),
+        str(get_num_avail_cores() - 1),
         "--force-as",
         "sph",
         "--preprocess",
@@ -1878,7 +1878,7 @@ def torch_dir(options):
             cur_token2id_txt,
             ref_dir,
             "--num-workers",
-            str(get_num_avail_cores()),
+            str(get_num_avail_cores() - 1),
         ]
         if not is_test and unk is not None:  # never write <UNK> for test
             args += ["--unk-symbol", unk]

--- a/wsj.py
+++ b/wsj.py
@@ -51,7 +51,7 @@ import pydrobert.speech.command_line as speech_cmd
 import pydrobert.torch.command_line as torch_cmd
 
 from unlzw import unlzw  # type: ignore
-from common import glob, mkdir, sort, cat, pipe_to, wc_l  # type: ignore
+from common import get_num_avail_cores, glob, mkdir, sort, cat, pipe_to, wc_l  # type: ignore
 
 locale.setlocale(locale.LC_ALL, "C")
 
@@ -1797,7 +1797,7 @@ def torch_dir(options):
         "--channel",
         "-1",
         "--num-workers",
-        str(torch.multiprocessing.cpu_count()),
+        str(get_num_avail_cores()),
         "--force-as",
         "sph",
         "--preprocess",
@@ -1873,7 +1873,13 @@ def torch_dir(options):
         else:
             cur_token2id_txt = token2id_txt
 
-        args = [trn_src, cur_token2id_txt, ref_dir]
+        args = [
+            trn_src,
+            cur_token2id_txt,
+            ref_dir,
+            "--num-workers",
+            str(get_num_avail_cores()),
+        ]
         if not is_test and unk is not None:  # never write <UNK> for test
             args += ["--unk-symbol", unk]
         torch_cmd.trn_to_torch_token_data_dir(args)


### PR DESCRIPTION
Ran into this when using SLURM. The number of cores from `os.cpu_count()` reflects the total number of cores on the machine, not the number we're allowed to use. If available, pulls the available count from `os.sched_getaffinity()`